### PR TITLE
Add PWM prescaler for TIM1 and TIM4 in device tree

### DIFF
--- a/boards/catie/zest_core_stm32l562ve/zest_core_stm32l562ve.dts
+++ b/boards/catie/zest_core_stm32l562ve/zest_core_stm32l562ve.dts
@@ -104,7 +104,7 @@
 };
 
 &timers1 {
-	st,prescaler = <1000>;
+	st,prescaler = <1>;
 	status = "okay";
 
 	pwm1: pwm {
@@ -121,7 +121,7 @@
 };
 
 &timers4 {
-	st,prescaler = <1000>;
+	st,prescaler = <1>;
 	status = "okay";
 
 	pwm3: pwm {

--- a/boards/catie/zest_core_stm32l562ve/zest_core_stm32l562ve.dts
+++ b/boards/catie/zest_core_stm32l562ve/zest_core_stm32l562ve.dts
@@ -104,6 +104,7 @@
 };
 
 &timers1 {
+	st,prescaler = <1000>;
 	status = "okay";
 
 	pwm1: pwm {
@@ -120,6 +121,7 @@
 };
 
 &timers4 {
+	st,prescaler = <1000>;
 	status = "okay";
 
 	pwm3: pwm {


### PR DESCRIPTION
Prescaler calculation for timers1 and timers4

Fpwm_min: 1 kHz
Fclock_max : 80Mhz ref to zest_core_stm32l562ve.dts
Resoltion : 16bits
Prescaler= {Fclock_max/(Fpwm_min×Resolution) } −1

Prescaler ≈1 (rounded up to the nearest integer).